### PR TITLE
Pin external actions for security

### DIFF
--- a/.github/workflows/push-docker-image-reusable.yml
+++ b/.github/workflows/push-docker-image-reusable.yml
@@ -52,14 +52,14 @@ jobs:
           echo ARTIFACT_PREFIX=${{ github.event.repository.name }}_${{ steps.release-version.outputs.RELEASE_VERSION }} >> $GITHUB_ENV
 
       - name: Download release asset amd64
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7
         with:
           version: tags/${{ inputs.release }}
           file: ${{ env.ARTIFACT_PREFIX }}_amd64.deb
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download release asset arm64
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7
         with:
           version: tags/${{ inputs.release }}
           file: ${{ env.ARTIFACT_PREFIX }}_arm64.deb


### PR DESCRIPTION
---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

Using the `@master` in GitHub Actions poses a security threat. There are actually [more](https://github.com/search?q=org%3Aanyproto+%2Fuses%3A%5B%5E%5Cn%5D%2B%40m%2F+%28path%3A.github%2Fworkflows%2F*.yml+OR+path%3A.github%2Fworkflows%2F*.yaml%29&type=code&p=1) to consider, but it seems that `fb929/github-action-fpm` is maintained by an active developer of anyproto.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
