### PR TITLE
GO-7185 fix calcMedian panic on empty input

### DIFF
--- a/nodestorage/stat.go
+++ b/nodestorage/stat.go
@@ -145,6 +145,9 @@ func calculateStatsPerObject(stats *ObjectSpaceStats) {
 }
 
 func calcMedian(sortedLengths []int) (median float64) {
+	if len(sortedLengths) == 0 {
+		return 0
+	}
 	mid := len(sortedLengths) / 2
 	if len(sortedLengths)%2 == 0 {
 		median = float64(sortedLengths[mid-1]+sortedLengths[mid]) / 2.0

--- a/nodestorage/stat_test.go
+++ b/nodestorage/stat_test.go
@@ -1,0 +1,20 @@
+package nodestorage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalcMedian(t *testing.T) {
+	t.Run("empty slice returns zero without panic", func(t *testing.T) {
+		assert.Equal(t, 0.0, calcMedian(nil))
+		assert.Equal(t, 0.0, calcMedian([]int{}))
+	})
+	t.Run("odd length", func(t *testing.T) {
+		assert.Equal(t, 3.0, calcMedian([]int{1, 2, 3, 4, 5}))
+	})
+	t.Run("even length", func(t *testing.T) {
+		assert.Equal(t, 2.5, calcMedian([]int{1, 2, 3, 4}))
+	})
+}


### PR DESCRIPTION
Guard against out-of-bounds indexing when the sorted slice is empty so GetSpaceStats stays safe under non-default debug endpoint usage.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
