### PR TITLE
indexstorage: drop legacy oh key

### DIFF
--- a/nodestorage/indexstorage.go
+++ b/nodestorage/indexstorage.go
@@ -49,7 +49,7 @@ const (
 	spaceCollName    = "space"
 	settingsCollName = "settings"
 	newHashKey       = "nh"
-	// oldHashKey is the legacy diff hash key: never written, only cleared
+	// oldHashKey is the legacy diff hash key: never written, deleted on update
 	oldHashKey                 = "oh"
 	statusKey                  = "s"
 	lastAccessKey              = "la"
@@ -104,6 +104,7 @@ func (d *indexStorage) UpdateHash(ctx context.Context, updates ...SpaceUpdate) (
 				update.Updated = time.Now()
 			}
 			v.Set(newHashKey, a.NewString(update.NewHash))
+			v.Del(oldHashKey)
 			v.Set(lastAccessKey, a.NewNumberFloat64(float64(update.Updated.Unix())))
 			if v.Get(statusKey) == nil {
 				v.Set(statusKey, a.NewNumberInt(int(SpaceStatusOk)))
@@ -216,7 +217,7 @@ func (d *indexStorage) SetSpaceStatus(ctx context.Context, spaceId string, statu
 		v.Set(statusKey, a.NewNumberInt(int(status)))
 		v.Set(lastAccessKey, a.NewNumberInt(int(time.Now().Unix())))
 		if status == SpaceStatusRemove {
-			v.Set(oldHashKey, a.NewNull())
+			v.Del(oldHashKey)
 			v.Set(newHashKey, a.NewNull())
 		}
 		return v, true, nil

--- a/nodestorage/indexstorage_test.go
+++ b/nodestorage/indexstorage_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	anystore "github.com/anyproto/any-store"
+	"github.com/anyproto/any-store/anyenc"
+	"github.com/anyproto/any-store/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -98,6 +100,31 @@ func Test_migrateToSingleCollection(t *testing.T) {
 	assert.NotContains(t, collNames, "deletionIndex")
 	assert.Contains(t, collNames, spaceCollName)
 	assert.Contains(t, collNames, settingsCollName)
+}
+
+func TestIndexStorage_NoLegacyOldHash(t *testing.T) {
+	tempDir := t.TempDir()
+	fx, err := createTestIndexStorage(ctx, tempDir)
+	require.NoError(t, err)
+	defer fx.Close()
+	coll := fx.(*indexStorage).spaceColl
+
+	// legacy doc carries "oh" written by an older version
+	_, err = coll.UpsertId(ctx, "legacy", query.ModifyFunc(func(a *anyenc.Arena, v *anyenc.Value) (*anyenc.Value, bool, error) {
+		v.Set(oldHashKey, a.NewString("old"))
+		return v, true, nil
+	}))
+	require.NoError(t, err)
+
+	require.NoError(t, fx.UpdateHash(ctx, SpaceUpdate{SpaceId: "legacy", NewHash: "new"}))
+	require.NoError(t, fx.UpdateHash(ctx, SpaceUpdate{SpaceId: "fresh", NewHash: "new"}))
+	require.NoError(t, fx.SetSpaceStatus(ctx, "removed", SpaceStatusRemove, ""))
+
+	for _, id := range []string{"legacy", "fresh", "removed"} {
+		doc, err := coll.FindId(ctx, id)
+		require.NoError(t, err)
+		assert.Nil(t, doc.Value().Get(oldHashKey), id)
+	}
 }
 
 func TestIndexStorage_MarkArchived(t *testing.T) {


### PR DESCRIPTION
The legacy diff hash key (`oh`) is dead since diffsync V2 removal (#231), but stale values written by older versions stay in existing space docs forever, and `SetSpaceStatus(Remove)` still writes an `oh: null` field into docs that never had one.

- `UpdateHash` deletes `oh` from the doc it rewrites, so legacy docs self-clean on their next hash update
- `SetSpaceStatus(Remove)` deletes the key instead of nulling it, so the field is never added

🤖 Generated with [Claude Code](https://claude.com/claude-code)